### PR TITLE
Fix strict-partitions

### DIFF
--- a/lib/Math/Sequences/Integer.pm6
+++ b/lib/Math/Sequences/Integer.pm6
@@ -283,7 +283,7 @@ sub strict-partitions(Int:D $n, Int :$target=$n) is export(:support) {
             default {
                 for strict-partitions($i-1, :target($remain)) -> $rest {
                     # Merge and add to results
-                    take ($i, $rest).map: |*;
+                    take ($i.Array, $rest.Array).map: |*;
                 }
             }
         }


### PR DESCRIPTION
Not entirely sure why this is a fix. Something about sequences being
lazy and they weren't getting evaluated at creation maybe?